### PR TITLE
Add qcom-caf /bootctrl to android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,6 +1,7 @@
 soong_namespace {
     imports: [
         "hardware/google/interfaces",
-        "hardware/google/pixel"
+        "hardware/google/pixel",
+        "hardware/qcom-caf/bootctrl"
     ],
 }


### PR DESCRIPTION
Imports qcom-caf/bootctrl to soong namespaces